### PR TITLE
LIBSEARCH-26 Modify Databases to link to the remote resource

### DIFF
--- a/app/searchers/quick_search/database_finder_searcher.rb
+++ b/app/searchers/quick_search/database_finder_searcher.rb
@@ -17,7 +17,7 @@ module QuickSearch
         search_result_list.each do |value|
           result = OpenStruct.new
           result.title = value['displayName']
-          result.link = value['detailLink']
+          result.link = value['hostUrl']
           result.description = value['description']
           @results_list << result
         end


### PR DESCRIPTION
This changes the link in the result.link to point to hostUrl instead of
detailLink.

https://issues.umd.edu/browse/LIBSEARCH-26