### PR TITLE
LIBSEARCH-39. Database entries without a hostUrl get a hyperlink of "#"

### DIFF
--- a/app/searchers/quick_search/database_finder_searcher.rb
+++ b/app/searchers/quick_search/database_finder_searcher.rb
@@ -36,8 +36,16 @@ module QuickSearch
     def results
       return @results_list if @results_list
       @results_list = @response['resultList'].map do |value|
+        # We want to show a result even if it doesn't have a hostUrl
+        # (some Database Finder entries point to services that are no
+        # no longer available, but are kept for historical/informational
+        # purposes). Since the NCSU QuickSearch code wants to suppress
+        # results without hostUrls, we'll default to "#" if the
+        # result doesn't have one.
+        host_url = value['hostUrl'].presence || '#'
+
         result = OpenStruct.new(title: value['displayName'],
-                                link: value['hostUrl'],
+                                link: host_url,
                                 description: build_description_block(value['description']),
                                 date: build_info_link(value['detailLink']))
         result.date << build_restricted_link if value['restricted']


### PR DESCRIPTION
Some Database Finder entries point to services that are no
no longer available, but are kept for historical/informational
purposes, such as "LexisNexis Academic".

Since the NCSU QuickSearch code wants to suppress results without
hostUrls, this modification sets a default hyperlink of "#" for
entries without a hostUrl. Clicking the title link will send the
user to the top of the page.

https://issues.umd.edu/browse/LIBSEARCH-39