### PR TITLE
LIBSEARCH-66. Modified code to URL encode search term

### DIFF
--- a/app/searchers/quick_search/database_finder_searcher.rb
+++ b/app/searchers/quick_search/database_finder_searcher.rb
@@ -58,7 +58,7 @@ module QuickSearch
     def search_url
       QuickSearch::Engine::DATABASE_FINDER_CONFIG['search_url'] +
         QuickSearch::Engine::DATABASE_FINDER_CONFIG['query_params'] +
-        http_request_queries['not_escaped']
+        http_request_queries['uri_escaped']
     end
 
     def total


### PR DESCRIPTION
Modified the code to use URL encoded (also know as "percent-encoding")
search terms for the HTTP request.

This ensures that search terms that include whitespace or quotes are
properly encoded for the request.

https://issues.umd.edu/browse/LIBSEARCH-66