### PR TITLE
LIBSEARCH-72. Changed user search query processing to be more permissive

### DIFF
--- a/app/searchers/quick_search/database_finder_searcher.rb
+++ b/app/searchers/quick_search/database_finder_searcher.rb
@@ -33,7 +33,7 @@ module QuickSearch
       content_tag(:div, raw(desc), class: ['block-with-text'])
     end
 
-    def results
+    def results # rubocop:disable Metrics/MethodLength
       return @results_list if @results_list
       @results_list = @response['resultList'].map do |value|
         # We want to show a result even if it doesn't have a hostUrl
@@ -58,7 +58,7 @@ module QuickSearch
     def search_url
       QuickSearch::Engine::DATABASE_FINDER_CONFIG['search_url'] +
         QuickSearch::Engine::DATABASE_FINDER_CONFIG['query_params'] +
-        http_request_queries['uri_escaped']
+        CGI.escape(sanitized_user_search_query)
     end
 
     def total
@@ -66,7 +66,15 @@ module QuickSearch
     end
 
     def loaded_link
-      QuickSearch::Engine::DATABASE_FINDER_CONFIG['loaded_link'] + http_request_queries['uri_escaped']
+      QuickSearch::Engine::DATABASE_FINDER_CONFIG['loaded_link'] + sanitized_user_search_query
+    end
+
+    # Returns the sanitized search query entered by the user, skipping
+    # the default QuickSearch query filtering
+    def sanitized_user_search_query
+      # Need to use "to_str" as otherwise Japanese text isn't returned
+      # properly
+      sanitize(@q).to_str
     end
   end
 end


### PR DESCRIPTION
The default QuickSearch user search query processing is very
restrictive, and prevents some common searches, such as those with
dashes. There were also difficulties with using search terms in foreign
languages such as Japanese.

Added "sanitized_user_search_query" method to return the user search
query that has only been passed through the "sanitize" method, which
results in a broader range of queries than that allows the default
QuickSearch user search query processing.

It is possible that even the "sanitize" method is not needed, but is
used here for whatever marginal benefit it might provide.

https://issues.umd.edu/browse/LIBSEARCH-72